### PR TITLE
Fix grub.cfg to not use consistent networking naming feature

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -4,6 +4,10 @@ set -x
 # Remove traces of MAC address and UUID from network configuration
 sed -E -i '/^(HWADDR|UUID)/d' /etc/sysconfig/network-scripts/ifcfg-e*
 
+# Add net.ifnames to /etc/default/grub and rebuild grub.cfg
+sed -i -e '/GRUB_CMDLINE_LINUX/ s:"$: net.ifnames=0":' /etc/default/grub
+/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+
 # Disable udev network rules
 ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 


### PR DESCRIPTION
RHEL7 supports the 'Consistent Network Naming' feature, that names devices after their physical location.  However, in a VM, this doesn't apply.  Furthermore, these packer scripts don't allow for it, since the udev rules are already disabled. This fix implements the net.ifnames=0 option, which is required by RHEL7.

This also fixes a bug where using the vmware-vmx builder with the VMX created by these templates will not work, since the network interface never comes up.
