### PR TITLE
Fix network startup issue in Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.iso
 *.tar
 *.swp
+ISOs/*
 crash.log
 output*
 .vagrant/

--- a/http/vbox-ks.cfg
+++ b/http/vbox-ks.cfg
@@ -35,4 +35,10 @@ useradd -u 9999 -g vagrant -G wheel vagrant
 echo "vagrant" | passwd --stdin vagrant
 sed -E -i '/Defaults[[:space:]]+requiretty/ s/^/#/' /etc/sudoers
 echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+
+# Fix for https://github.com/CentOS/sig-cloud-instance-build/issues/38
+cat >> /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
+DEVICE="eth0"
+EOF
+
 %end


### PR DESCRIPTION
When starting up RHEL in Vagrant, network service failed - tracked it down to `ifcfg-eth0` not having `DEVICE` declared.